### PR TITLE
Support UMD

### DIFF
--- a/src/mui/Colors.hx
+++ b/src/mui/Colors.hx
@@ -1,6 +1,6 @@
 package mui;
 
-@:jsRequire('@material-ui/core', 'colors')
+#if mui.global @:native('MaterialUI.colors') #else @:jsRequire('@material-ui/core', 'colors') #end
 extern class Colors {
 	static var amber:ColorDefinition;
 	static var blue:ColorDefinition;

--- a/src/mui/core/AppBar.hx
+++ b/src/mui/core/AppBar.hx
@@ -12,7 +12,7 @@ typedef AppBarProps = ForcedOverride<PaperProps, {
 	@:optional var position:CSSPosition;
 }>;
 
-@:jsRequire('@material-ui/core', 'AppBar')
+#if mui.global @:native('MaterialUI.AppBar') #else @:jsRequire('@material-ui/core', 'AppBar') #end
 extern class AppBar extends ReactComponentOfProps<AppBarProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<AppBarClassKey>
 		return AppBarStyles.styles(theme);

--- a/src/mui/core/Avatar.hx
+++ b/src/mui/core/Avatar.hx
@@ -18,7 +18,7 @@ typedef AvatarProps = {
 	@:optional var variant:AvatarVariant;
 }
 
-@:jsRequire('@material-ui/core', 'Avatar')
+#if mui.global @:native('MaterialUI.Avatar') #else @:jsRequire('@material-ui/core', 'Avatar') #end
 extern class Avatar extends ReactComponentOfProps<AvatarProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<AvatarClassKey>
 		return AvatarStyles.styles(theme);

--- a/src/mui/core/Backdrop.hx
+++ b/src/mui/core/Backdrop.hx
@@ -14,7 +14,7 @@ typedef BackdropProps = {
 	@:optional var transitionDuration:TimeoutTransitionDuration;
 }
 
-@:jsRequire('@material-ui/core', 'Backdrop')
+#if mui.global @:native('MaterialUI.Backdrop') #else @:jsRequire('@material-ui/core', 'Backdrop') #end
 extern class Backdrop extends ReactComponentOfProps<BackdropProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<BackdropClassKey>
 		return BackdropStyles.styles;

--- a/src/mui/core/Badge.hx
+++ b/src/mui/core/Badge.hx
@@ -24,7 +24,7 @@ typedef BadgeProps = {
 	@:optional var variant:BadgeVariant;
 }
 
-@:jsRequire('@material-ui/core', 'Badge')
+#if mui.global @:native('MaterialUI.Badge') #else @:jsRequire('@material-ui/core', 'Badge') #end
 extern class Badge extends ReactComponentOfProps<BadgeProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<BadgeClassKey>
 		return BadgeStyles.styles(theme);

--- a/src/mui/core/BottomNavigation.hx
+++ b/src/mui/core/BottomNavigation.hx
@@ -12,7 +12,7 @@ typedef BottomNavigationProps = ForcedOverride<StandardDOMAttributes, {
 	@:optional var value:Any;
 }>;
 
-@:jsRequire('@material-ui/core', 'BottomNavigation')
+#if mui.global @:native('MaterialUI.BottomNavigation') #else @:jsRequire('@material-ui/core', 'BottomNavigation') #end
 extern class BottomNavigation extends ReactComponentOfProps<BottomNavigationProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<BottomNavigationClassKey>
 		return BottomNavigationStyles.styles(theme);

--- a/src/mui/core/BottomNavigationAction.hx
+++ b/src/mui/core/BottomNavigationAction.hx
@@ -13,7 +13,7 @@ typedef BottomNavigationActionProps = ForcedOverride<ButtonBaseProps, {
 	@:optional var value:Any;
 }>;
 
-@:jsRequire('@material-ui/core', 'BottomNavigationAction')
+#if mui.global @:native('MaterialUI.BottomNavigationAction') #else @:jsRequire('@material-ui/core', 'BottomNavigationAction') #end
 extern class BottomNavigationAction extends ReactComponentOfProps<BottomNavigationActionProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<BottomNavigationActionClassKey>
 		return BottomNavigationActionStyles.styles(theme);

--- a/src/mui/core/Breadcrumbs.hx
+++ b/src/mui/core/Breadcrumbs.hx
@@ -15,7 +15,7 @@ typedef BreadcrumbsProps = {
 	@:optional var separator:ReactSingleFragment;
 }
 
-@:jsRequire('@material-ui/core', 'Breadcrumbs')
+#if mui.global @:native('MaterialUI.Breadcrumbs') #else @:jsRequire('@material-ui/core', 'Breadcrumbs') #end
 extern class Breadcrumbs extends ReactComponentOfProps<BreadcrumbsProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<BreadcrumbsClassKey>
 		return BreadcrumbsStyles.styles;

--- a/src/mui/core/Button.hx
+++ b/src/mui/core/Button.hx
@@ -41,7 +41,7 @@ typedef ButtonProps = {
 	@:optional var tabIndex:Int;
 }
 
-@:jsRequire('@material-ui/core', 'Button')
+#if mui.global @:native('MaterialUI.Button') #else @:jsRequire('@material-ui/core', 'Button') #end
 extern class Button extends ReactComponentOfProps<ButtonProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<ButtonClassKey>
 		return ButtonStyles.styles(theme);

--- a/src/mui/core/ButtonBase.hx
+++ b/src/mui/core/ButtonBase.hx
@@ -24,7 +24,7 @@ typedef ButtonBaseProps = {
 	@:optional var type:ButtonType;
 }
 
-@:jsRequire('@material-ui/core', 'ButtonBase')
+#if mui.global @:native('MaterialUI.ButtonBase') #else @:jsRequire('@material-ui/core', 'ButtonBase') #end
 extern class ButtonBase extends ReactComponentOfProps<ButtonBaseProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<ButtonBaseClassKey>
 		return ButtonBaseStyles.styles;

--- a/src/mui/core/ButtonGroup.hx
+++ b/src/mui/core/ButtonGroup.hx
@@ -20,7 +20,7 @@ typedef ButtonGroupProps = {
 	@:optional var variant:ButtonVariant;
 }
 
-@:jsRequire('@material-ui/core', 'ButtonGroup')
+#if mui.global @:native('MaterialUI.ButtonGroup') #else @:jsRequire('@material-ui/core', 'ButtonGroup') #end
 extern class ButtonGroup extends ReactComponentOfProps<ButtonGroupProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<ButtonGroupClassKey>
 		return ButtonGroupStyles.styles(theme);

--- a/src/mui/core/Card.hx
+++ b/src/mui/core/Card.hx
@@ -9,7 +9,7 @@ typedef CardProps = ForcedOverride<PaperProps, {
 	@:optional var raised:Bool;
 }>;
 
-@:jsRequire('@material-ui/core', 'Card')
+#if mui.global @:native('MaterialUI.Card') #else @:jsRequire('@material-ui/core', 'Card') #end
 extern class Card extends ReactComponentOfProps<CardProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<CardClassKey>
 		return CardStyles.styles;

--- a/src/mui/core/CardActionArea.hx
+++ b/src/mui/core/CardActionArea.hx
@@ -8,7 +8,7 @@ typedef CardActionAreaProps = ForcedOverride<ButtonBaseProps, {
 	@:optional var classes:Record<CardActionAreaClassKey>;
 }>;
 
-@:jsRequire('@material-ui/core', 'CardActionArea')
+#if mui.global @:native('MaterialUI.CardActionArea') #else @:jsRequire('@material-ui/core', 'CardActionArea') #end
 extern class CardActionArea extends ReactComponentOfProps<CardActionAreaProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<CardActionAreaClassKey>
 		return CardActionAreaStyles.styles(theme);

--- a/src/mui/core/CardActions.hx
+++ b/src/mui/core/CardActions.hx
@@ -11,7 +11,7 @@ typedef CardActionsProps = {
 	@:optional var disableSpacing:Bool;
 }
 
-@:jsRequire('@material-ui/core', 'CardActions')
+#if mui.global @:native('MaterialUI.CardActions') #else @:jsRequire('@material-ui/core', 'CardActions') #end
 extern class CardActions extends ReactComponentOfProps<CardActionsProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<CardActionsClassKey>
 		return CardActionsStyles.styles;

--- a/src/mui/core/CardContent.hx
+++ b/src/mui/core/CardContent.hx
@@ -11,7 +11,7 @@ typedef CardContentProps = {
 	@:optional var component:ReactType;
 }
 
-@:jsRequire('@material-ui/core', 'CardContent')
+#if mui.global @:native('MaterialUI.CardContent') #else @:jsRequire('@material-ui/core', 'CardContent') #end
 extern class CardContent extends ReactComponentOfProps<CardContentProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<CardContentClassKey>
 		return CardContentStyles.styles;

--- a/src/mui/core/CardHeader.hx
+++ b/src/mui/core/CardHeader.hx
@@ -17,7 +17,7 @@ typedef CardHeaderProps = ForcedOverride<StandardDOMAttributes, {
 	@:optional var titleTypographyProps:Partial<TypographyProps>;
 }>;
 
-@:jsRequire('@material-ui/core', 'CardHeader')
+#if mui.global @:native('MaterialUI.CardHeader') #else @:jsRequire('@material-ui/core', 'CardHeader') #end
 extern class CardHeader extends ReactComponentOfProps<CardHeaderProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<CardHeaderClassKey>
 		return CardHeaderStyles.styles;

--- a/src/mui/core/CardMedia.hx
+++ b/src/mui/core/CardMedia.hx
@@ -13,7 +13,7 @@ typedef CardMediaProps = {
 	@:optional var src:String;
 }
 
-@:jsRequire('@material-ui/core', 'CardMedia')
+#if mui.global @:native('MaterialUI.CardMedia') #else @:jsRequire('@material-ui/core', 'CardMedia') #end
 extern class CardMedia extends ReactComponentOfProps<CardMediaProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<CardMediaClassKey>
 		return CardMediaStyles.styles;

--- a/src/mui/core/Checkbox.hx
+++ b/src/mui/core/Checkbox.hx
@@ -29,7 +29,7 @@ typedef CheckboxProps = ForcedOverride<IconButtonProps, {
 	@:optional var value:String;
 }>;
 
-@:jsRequire('@material-ui/core', 'Checkbox')
+#if mui.global @:native('MaterialUI.Checkbox') #else @:jsRequire('@material-ui/core', 'Checkbox') #end
 extern class Checkbox extends ReactComponentOfProps<CheckboxProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<CheckboxClassKey>
 		return CheckboxStyles.styles(theme);

--- a/src/mui/core/Chip.hx
+++ b/src/mui/core/Chip.hx
@@ -23,7 +23,7 @@ typedef ChipProps = ForcedOverride<StandardDOMAttributes, {
 	@:optional var variant:ChipVariant;
 }>;
 
-@:jsRequire('@material-ui/core', 'Chip')
+#if mui.global @:native('MaterialUI.Chip') #else @:jsRequire('@material-ui/core', 'Chip') #end
 extern class Chip extends ReactComponentOfProps<ChipProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<ChipClassKey>
 		return ChipStyles.styles(theme);

--- a/src/mui/core/CircularProgress.hx
+++ b/src/mui/core/CircularProgress.hx
@@ -19,7 +19,7 @@ typedef CircularProgressProps = {
 	@:optional var variant:CircularProgressVariant;
 }
 
-@:jsRequire('@material-ui/core', 'CircularProgress')
+#if mui.global @:native('MaterialUI.CircularProgress') #else @:jsRequire('@material-ui/core', 'CircularProgress') #end
 extern class CircularProgress extends ReactComponentOfProps<CircularProgressProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<CircularProgressClassKey>
 		return CircularProgressStyles.styles(theme);

--- a/src/mui/core/ClickAwayListener.hx
+++ b/src/mui/core/ClickAwayListener.hx
@@ -20,5 +20,5 @@ typedef ClickAwayListenerProps = {
 	var None = false;
 }
 
-@:jsRequire('@material-ui/core', 'ClickAwayListener')
+#if mui.global @:native('MaterialUI.ClickAwayListener') #else @:jsRequire('@material-ui/core', 'ClickAwayListener') #end
 extern class ClickAwayListener extends ReactComponentOfProps<ClickAwayListenerProps> {}

--- a/src/mui/core/Collapse.hx
+++ b/src/mui/core/Collapse.hx
@@ -18,7 +18,7 @@ typedef CollapseProps = ForcedOverride<TransitionProps<Any>, {
 }>;
 
 @:acceptsMoreProps('react.transition.Transition')
-@:jsRequire('@material-ui/core', 'Collapse')
+#if mui.global @:native('MaterialUI.Collapse') #else @:jsRequire('@material-ui/core', 'Collapse') #end
 extern class Collapse extends ReactComponentOfProps<CollapseProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<CollapseClassKey>
 		return CollapseStyles.styles(theme);

--- a/src/mui/core/Container.hx
+++ b/src/mui/core/Container.hx
@@ -14,7 +14,7 @@ typedef ContainerProps = {
 	@:optional var maxWidth:BreakpointOrFalse;
 };
 
-@:jsRequire('@material-ui/core', 'Container')
+#if mui.global @:native('MaterialUI.Container') #else @:jsRequire('@material-ui/core', 'Container') #end
 extern class Container extends ReactComponentOfProps<ContainerProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<ContainerClassKey>
 		return ContainerStyles.styles(theme);

--- a/src/mui/core/CssBaseline.hx
+++ b/src/mui/core/CssBaseline.hx
@@ -6,6 +6,6 @@ typedef CssBaselineProps = {
 	@:optional var children:ReactFragment;
 }
 
-@:jsRequire('@material-ui/core', 'CssBaseline')
+#if mui.global @:native('MaterialUI.CssBaseline') #else @:jsRequire('@material-ui/core', 'CssBaseline') #end
 extern class CssBaseline extends ReactComponentOfProps<CssBaselineProps> {}
 

--- a/src/mui/core/Dialog.hx
+++ b/src/mui/core/Dialog.hx
@@ -30,7 +30,7 @@ typedef DialogProps = ForcedOverride<ModalProps, {
 	@:optional var TransitionProps:TransitionProps<Any>;
 }>;
 
-@:jsRequire('@material-ui/core', 'Dialog')
+#if mui.global @:native('MaterialUI.Dialog') #else @:jsRequire('@material-ui/core', 'Dialog') #end
 extern class Dialog extends ReactComponentOfProps<DialogProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<DialogClassKey>
 		return DialogStyles.styles(theme);

--- a/src/mui/core/DialogActions.hx
+++ b/src/mui/core/DialogActions.hx
@@ -11,7 +11,7 @@ typedef DialogActionsProps = {
 	@:optional var disableSpacing:Bool;
 }
 
-@:jsRequire('@material-ui/core', 'DialogActions')
+#if mui.global @:native('MaterialUI.DialogActions') #else @:jsRequire('@material-ui/core', 'DialogActions') #end
 extern class DialogActions extends ReactComponentOfProps<DialogActionsProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<DialogActionsClassKey>
 		return DialogActionsStyles.styles;

--- a/src/mui/core/DialogContent.hx
+++ b/src/mui/core/DialogContent.hx
@@ -11,7 +11,7 @@ typedef DialogContentProps = {
 	@:optional var dividers:Bool;
 }
 
-@:jsRequire('@material-ui/core', 'DialogContent')
+#if mui.global @:native('MaterialUI.DialogContent') #else @:jsRequire('@material-ui/core', 'DialogContent') #end
 extern class DialogContent extends ReactComponentOfProps<DialogContentProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<DialogContentClassKey>
 		return DialogContentStyles.styles(theme);

--- a/src/mui/core/DialogContentText.hx
+++ b/src/mui/core/DialogContentText.hx
@@ -8,7 +8,7 @@ typedef DialogContentTextProps = ForcedOverride<TypographyProps, {
 	@:optional var classes:Record<DialogContentTextClassKey>;
 }>;
 
-@:jsRequire('@material-ui/core', 'DialogContentText')
+#if mui.global @:native('MaterialUI.DialogContentText') #else @:jsRequire('@material-ui/core', 'DialogContentText') #end
 extern class DialogContentText extends ReactComponentOfProps<DialogContentTextProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<DialogContentTextClassKey>
 		return DialogContentTextStyles.styles;

--- a/src/mui/core/DialogTitle.hx
+++ b/src/mui/core/DialogTitle.hx
@@ -11,7 +11,7 @@ typedef DialogTitleProps = {
 	@:optional var disableTypography:Bool;
 }
 
-@:jsRequire('@material-ui/core', 'DialogTitle')
+#if mui.global @:native('MaterialUI.DialogTitle') #else @:jsRequire('@material-ui/core', 'DialogTitle') #end
 extern class DialogTitle extends ReactComponentOfProps<DialogTitleProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<DialogTitleClassKey>
 		return DialogTitleStyles.styles;

--- a/src/mui/core/Divider.hx
+++ b/src/mui/core/Divider.hx
@@ -17,7 +17,7 @@ typedef DividerProps = {
 	@:optional var variant:DividerVariant;
 }
 
-@:jsRequire('@material-ui/core', 'Divider')
+#if mui.global @:native('MaterialUI.Divider') #else @:jsRequire('@material-ui/core', 'Divider') #end
 extern class Divider extends ReactComponentOfProps<DividerProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<DividerClassKey>
 		return DividerStyles.styles(theme);

--- a/src/mui/core/Drawer.hx
+++ b/src/mui/core/Drawer.hx
@@ -25,7 +25,7 @@ typedef DrawerProps = {
 	@:optional var variant:DrawerVariant;
 }
 
-@:jsRequire('@material-ui/core', 'Drawer')
+#if mui.global @:native('MaterialUI.Drawer') #else @:jsRequire('@material-ui/core', 'Drawer') #end
 extern class Drawer extends ReactComponentOfProps<DrawerProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<DrawerClassKey>
 		return DrawerStyles.styles(theme);

--- a/src/mui/core/ExpansionPanel.hx
+++ b/src/mui/core/ExpansionPanel.hx
@@ -17,7 +17,7 @@ typedef ExpansionPanelProps = ForcedOverride<PaperProps, {
 	@:optional var TransitionProps:TransitionProps<Any>;
 }>;
 
-@:jsRequire('@material-ui/core', 'ExpansionPanel')
+#if mui.global @:native('MaterialUI.ExpansionPanel') #else @:jsRequire('@material-ui/core', 'ExpansionPanel') #end
 extern class ExpansionPanel extends ReactComponentOfProps<ExpansionPanelProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<ExpansionPanelClassKey>
 		return ExpansionPanelStyles.styles(theme);

--- a/src/mui/core/ExpansionPanelActions.hx
+++ b/src/mui/core/ExpansionPanelActions.hx
@@ -11,7 +11,7 @@ typedef ExpansionPanelActionsProps = {
 	@:optional var disableSpacing:Bool;
 }
 
-@:jsRequire('@material-ui/core', 'ExpansionPanelActions')
+#if mui.global @:native('MaterialUI.ExpansionPanelActions') #else @:jsRequire('@material-ui/core', 'ExpansionPanelActions') #end
 extern class ExpansionPanelActions extends ReactComponentOfProps<ExpansionPanelActionsProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<ExpansionPanelActionsClassKey>
 		return ExpansionPanelActionsStyles.styles;

--- a/src/mui/core/ExpansionPanelDetails.hx
+++ b/src/mui/core/ExpansionPanelDetails.hx
@@ -10,7 +10,7 @@ typedef ExpansionPanelDetailsProps = {
 	@:optional var classes:Record<ExpansionPanelDetailsClassKey>;
 }
 
-@:jsRequire('@material-ui/core', 'ExpansionPanelDetails')
+#if mui.global @:native('MaterialUI.ExpansionPanelDetails') #else @:jsRequire('@material-ui/core', 'ExpansionPanelDetails') #end
 extern class ExpansionPanelDetails extends ReactComponentOfProps<ExpansionPanelDetailsProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<ExpansionPanelDetailsClassKey>
 		return ExpansionPanelDetailsStyles.styles;

--- a/src/mui/core/ExpansionPanelSummary.hx
+++ b/src/mui/core/ExpansionPanelSummary.hx
@@ -13,7 +13,7 @@ typedef ExpansionPanelSummaryProps = {
 	@:optional var IconButtonProps:Partial<IconButtonProps>;
 }
 
-@:jsRequire('@material-ui/core', 'ExpansionPanelSummary')
+#if mui.global @:native('MaterialUI.ExpansionPanelSummary') #else @:jsRequire('@material-ui/core', 'ExpansionPanelSummary') #end
 extern class ExpansionPanelSummary extends ReactComponentOfProps<ExpansionPanelSummaryProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<ExpansionPanelSummaryClassKey>
 		return ExpansionPanelSummaryStyles.styles(theme);

--- a/src/mui/core/Fab.hx
+++ b/src/mui/core/Fab.hx
@@ -16,7 +16,7 @@ typedef FabProps = ForcedOverride<ButtonBaseProps, {
 	@:optional var variant:FabVariant;
 }>;
 
-@:jsRequire('@material-ui/core', 'Fab')
+#if mui.global @:native('MaterialUI.Fab') #else @:jsRequire('@material-ui/core', 'Fab') #end
 extern class Fab extends ReactComponentOfProps<FabProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<FabClassKey>
 		return FabStyles.styles(theme);

--- a/src/mui/core/Fade.hx
+++ b/src/mui/core/Fade.hx
@@ -4,5 +4,5 @@ import react.ReactComponent;
 import react.transition.Transition;
 
 @:acceptsMoreProps('react.transition.Transition')
-@:jsRequire('@material-ui/core', 'Fade')
+#if mui.global @:native('MaterialUI.Fade') #else @:jsRequire('@material-ui/core', 'Fade') #end
 extern class Fade<TChildProps> extends ReactComponentOfProps<TransitionProps<TChildProps>> {}

--- a/src/mui/core/FilledInput.hx
+++ b/src/mui/core/FilledInput.hx
@@ -10,7 +10,7 @@ typedef FilledInputProps = ForcedOverride<InputBaseProps, {
 	@:optional var disableUnderline:Bool;
 }>;
 
-@:jsRequire('@material-ui/core', 'FilledInput')
+#if mui.global @:native('MaterialUI.FilledInput') #else @:jsRequire('@material-ui/core', 'FilledInput') #end
 extern class FilledInput extends ReactComponentOfProps<FilledInputProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<FilledInputClassKey>
 		return FilledInputStyles.styles(theme);

--- a/src/mui/core/FormControl.hx
+++ b/src/mui/core/FormControl.hx
@@ -24,7 +24,7 @@ typedef FormControlProps = {
 	@:optional var variant:FormControlVariant;
 }
 
-@:jsRequire('@material-ui/core', 'FormControl')
+#if mui.global @:native('MaterialUI.FormControl') #else @:jsRequire('@material-ui/core', 'FormControl') #end
 extern class FormControl extends ReactComponentOfProps<FormControlProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<FormControlClassKey>
 		return FormControlStyles.styles;

--- a/src/mui/core/FormControlLabel.hx
+++ b/src/mui/core/FormControlLabel.hx
@@ -22,7 +22,7 @@ typedef FormControlLabelProps = ForcedOverride<StandardDOMAttributes, {
 	@:optional var value:String;
 }>;
 
-@:jsRequire('@material-ui/core', 'FormControlLabel')
+#if mui.global @:native('MaterialUI.FormControlLabel') #else @:jsRequire('@material-ui/core', 'FormControlLabel') #end
 extern class FormControlLabel extends ReactComponentOfProps<FormControlLabelProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<FormControlLabelClassKey>
 		return FormControlLabelStyles.styles(theme);

--- a/src/mui/core/FormGroup.hx
+++ b/src/mui/core/FormGroup.hx
@@ -11,7 +11,7 @@ typedef FormGroupProps = {
 	@:optional var row:Bool;
 }
 
-@:jsRequire('@material-ui/core', 'FormGroup')
+#if mui.global @:native('MaterialUI.FormGroup') #else @:jsRequire('@material-ui/core', 'FormGroup') #end
 extern class FormGroup extends ReactComponentOfProps<FormGroupProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<FormGroupClassKey>
 		return FormGroupStyles.styles;

--- a/src/mui/core/FormHelperText.hx
+++ b/src/mui/core/FormHelperText.hx
@@ -20,7 +20,7 @@ typedef FormHelperTextProps = {
 	@:optional var variant:FormControlVariant;
 }
 
-@:jsRequire('@material-ui/core', 'FormHelperText')
+#if mui.global @:native('MaterialUI.FormHelperText') #else @:jsRequire('@material-ui/core', 'FormHelperText') #end
 extern class FormHelperText extends ReactComponentOfProps<FormHelperTextProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<FormHelperTextClassKey>
 		return FormHelperTextStyles.styles(theme);

--- a/src/mui/core/FormLabel.hx
+++ b/src/mui/core/FormLabel.hx
@@ -19,7 +19,7 @@ typedef FormLabelProps = {
 	@:optional var htmlFor:String;
 }
 
-@:jsRequire('@material-ui/core', 'FormLabel')
+#if mui.global @:native('MaterialUI.FormLabel') #else @:jsRequire('@material-ui/core', 'FormLabel') #end
 extern class FormLabel extends ReactComponentOfProps<FormLabelProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<FormLabelClassKey>
 		return FormLabelStyles.styles(theme);

--- a/src/mui/core/Grid.hx
+++ b/src/mui/core/Grid.hx
@@ -33,7 +33,7 @@ typedef GridProps = {
 	@:optional var zeroMinWidth:Bool;
 }
 
-@:jsRequire('@material-ui/core', 'Grid')
+#if mui.global @:native('MaterialUI.Grid') #else @:jsRequire('@material-ui/core', 'Grid') #end
 extern class Grid extends ReactComponentOfProps<GridProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<GridClassKey>
 		return GridStyles.styles(theme);

--- a/src/mui/core/GridList.hx
+++ b/src/mui/core/GridList.hx
@@ -13,7 +13,7 @@ typedef GridListProps = ForcedOverride<StandardDOMAttributes, {
 	@:optional var spacing:Int;
 }>;
 
-@:jsRequire('@material-ui/core', 'GridList')
+#if mui.global @:native('MaterialUI.GridList') #else @:jsRequire('@material-ui/core', 'GridList') #end
 extern class GridList extends ReactComponentOfProps<GridListProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<GridListClassKey>
 		return GridListStyles.styles;

--- a/src/mui/core/GridListTile.hx
+++ b/src/mui/core/GridListTile.hx
@@ -13,7 +13,7 @@ typedef GridListTileProps = {
 	@:optional var rows:Int;
 }
 
-@:jsRequire('@material-ui/core', 'GridListTile')
+#if mui.global @:native('MaterialUI.GridListTile') #else @:jsRequire('@material-ui/core', 'GridListTile') #end
 extern class GridListTile extends ReactComponentOfProps<GridListTileProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<GridListTileClassKey>
 		return GridListTileStyles.styles;

--- a/src/mui/core/GridListTileBar.hx
+++ b/src/mui/core/GridListTileBar.hx
@@ -14,7 +14,7 @@ typedef GridListTileBarProps = ForcedOverride<StandardDOMAttributes, {
 	@:optional var titlePosition:TopOrBottom;
 }>;
 
-@:jsRequire('@material-ui/core', 'GridListTileBar')
+#if mui.global @:native('MaterialUI.GridListTileBar') #else @:jsRequire('@material-ui/core', 'GridListTileBar') #end
 extern class GridListTileBar extends ReactComponentOfProps<GridListTileBarProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<GridListTileBarClassKey>
 		return GridListTileBarStyles.styles(theme);

--- a/src/mui/core/Grow.hx
+++ b/src/mui/core/Grow.hx
@@ -11,5 +11,5 @@ typedef GrowProps = ForcedOverride<TransitionProps<Any>, {
 }>;
 
 @:acceptsMoreProps('react.transition.Transition')
-@:jsRequire('@material-ui/core', 'Grow')
+#if mui.global @:native('MaterialUI.Grow') #else @:jsRequire('@material-ui/core', 'Grow') #end
 extern class Grow extends ReactComponentOfProps<GrowProps> {}

--- a/src/mui/core/Hidden.hx
+++ b/src/mui/core/Hidden.hx
@@ -22,5 +22,5 @@ private typedef Props = {
 	@:optional var className:String;
 }
 
-@:jsRequire('@material-ui/core', 'Hidden')
+#if mui.global @:native('MaterialUI.Hidden') #else @:jsRequire('@material-ui/core', 'Hidden') #end
 extern class Hidden extends ReactComponentOfProps<Props> {}

--- a/src/mui/core/IconButton.hx
+++ b/src/mui/core/IconButton.hx
@@ -14,7 +14,7 @@ typedef IconButtonProps = ForcedOverride<ButtonBaseProps, {
 	@:optional var size:IconButtonSize;
 }>;
 
-@:jsRequire('@material-ui/core', 'IconButton')
+#if mui.global @:native('MaterialUI.IconButton') #else @:jsRequire('@material-ui/core', 'IconButton') #end
 extern class IconButton extends ReactComponentOfProps<IconButtonProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<IconButtonClassKey>
 		return IconButtonStyles.styles(theme);

--- a/src/mui/core/Input.hx
+++ b/src/mui/core/Input.hx
@@ -10,7 +10,7 @@ typedef InputProps = ForcedOverride<InputBaseProps, {
 	@:optional var disableUnderline:Bool;
 }>;
 
-@:jsRequire('@material-ui/core', 'Input')
+#if mui.global @:native('MaterialUI.Input') #else @:jsRequire('@material-ui/core', 'Input') #end
 extern class Input extends ReactComponentOfProps<InputProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<InputClassKey>
 		return InputStyles.styles(theme);

--- a/src/mui/core/InputAdornment.hx
+++ b/src/mui/core/InputAdornment.hx
@@ -17,7 +17,7 @@ typedef InputAdornmentProps = {
 	@:optional var variant:FormControlVariant;
 }
 
-@:jsRequire('@material-ui/core', 'InputAdornment')
+#if mui.global @:native('MaterialUI.InputAdornment') #else @:jsRequire('@material-ui/core', 'InputAdornment') #end
 extern class InputAdornment extends ReactComponentOfProps<InputAdornmentProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<InputAdornmentClassKey>
 		return InputAdornmentStyles.styles;

--- a/src/mui/core/InputBase.hx
+++ b/src/mui/core/InputBase.hx
@@ -44,7 +44,7 @@ typedef InputBaseCommonProps = {
 	@:optional var value:InputValue;
 }
 
-@:jsRequire('@material-ui/core', 'InputBase')
+#if mui.global @:native('MaterialUI.InputBase') #else @:jsRequire('@material-ui/core', 'InputBase') #end
 extern class InputBase extends ReactComponentOfProps<InputBaseProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<InputBaseClassKey>
 		return InputBaseStyles.styles(theme);

--- a/src/mui/core/InputLabel.hx
+++ b/src/mui/core/InputLabel.hx
@@ -16,7 +16,7 @@ typedef InputLabelProps = ForcedOverride<FormLabelProps, {
 	@:optional var variant:FormControlVariant;
 }>;
 
-@:jsRequire('@material-ui/core', 'InputLabel')
+#if mui.global @:native('MaterialUI.InputLabel') #else @:jsRequire('@material-ui/core', 'InputLabel') #end
 extern class InputLabel extends ReactComponentOfProps<InputLabelProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<InputLabelClassKey>
 		return InputLabelStyles.styles(theme);

--- a/src/mui/core/LinearProgress.hx
+++ b/src/mui/core/LinearProgress.hx
@@ -16,7 +16,7 @@ typedef LinearProgressProps = {
 	@:optional var variant:LinearProgressVariant;
 }
 
-@:jsRequire('@material-ui/core', 'LinearProgress')
+#if mui.global @:native('MaterialUI.LinearProgress') #else @:jsRequire('@material-ui/core', 'LinearProgress') #end
 extern class LinearProgress extends ReactComponentOfProps<LinearProgressProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<LinearProgressClassKey>
 		return LinearProgressStyles.styles(theme);

--- a/src/mui/core/Link.hx
+++ b/src/mui/core/Link.hx
@@ -17,7 +17,7 @@ typedef LinkProps = ForcedOverride<TypographyProps, {
 	@:optional var underline:LinkUnderline;
 }>;
 
-@:jsRequire('@material-ui/core', 'Link')
+#if mui.global @:native('MaterialUI.Link') #else @:jsRequire('@material-ui/core', 'Link') #end
 extern class Link extends ReactComponentOfProps<LinkProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<LinkClassKey>
 		return LinkStyles.styles;

--- a/src/mui/core/List.hx
+++ b/src/mui/core/List.hx
@@ -14,7 +14,7 @@ typedef ListProps = {
 	@:optional var subheader:ReactFragment;
 }
 
-@:jsRequire('@material-ui/core', 'List')
+#if mui.global @:native('MaterialUI.List') #else @:jsRequire('@material-ui/core', 'List') #end
 extern class List extends ReactComponentOfProps<ListProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<ListClassKey>
 		return ListStyles.styles;

--- a/src/mui/core/ListItem.hx
+++ b/src/mui/core/ListItem.hx
@@ -20,7 +20,7 @@ typedef ListItemProps = ForcedOverride<ButtonBaseProps, {
 	@:optional var selected:Bool;
 }>;
 
-@:jsRequire('@material-ui/core', 'ListItem')
+#if mui.global @:native('MaterialUI.ListItem') #else @:jsRequire('@material-ui/core', 'ListItem') #end
 extern class ListItem extends ReactComponentOfProps<ListItemProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<ListItemClassKey>
 		return ListItemStyles.styles(theme);

--- a/src/mui/core/ListItemAvatar.hx
+++ b/src/mui/core/ListItemAvatar.hx
@@ -10,7 +10,7 @@ typedef ListItemAvatarProps = {
 	@:optional var classes:Record<ListItemAvatarClassKey>;
 }
 
-@:jsRequire('@material-ui/core', 'ListItemAvatar')
+#if mui.global @:native('MaterialUI.ListItemAvatar') #else @:jsRequire('@material-ui/core', 'ListItemAvatar') #end
 extern class ListItemAvatar extends ReactComponentOfProps<ListItemAvatarProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<ListItemAvatarClassKey>
 		return ListItemAvatarStyles.styles;

--- a/src/mui/core/ListItemIcon.hx
+++ b/src/mui/core/ListItemIcon.hx
@@ -10,7 +10,7 @@ typedef ListItemIconProps = {
 	@:optional var classes:Record<ListItemIconClassKey>;
 }
 
-@:jsRequire('@material-ui/core', 'ListItemIcon')
+#if mui.global @:native('MaterialUI.ListItemIcon') #else @:jsRequire('@material-ui/core', 'ListItemIcon') #end
 extern class ListItemIcon extends ReactComponentOfProps<ListItemIconProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<ListItemIconClassKey>
 		return ListItemIconStyles.styles(theme);

--- a/src/mui/core/ListItemSecondaryAction.hx
+++ b/src/mui/core/ListItemSecondaryAction.hx
@@ -10,7 +10,7 @@ typedef ListItemSecondaryActionProps = {
 	@:optional var classes:Record<ListItemSecondaryActionClassKey>;
 }
 
-@:jsRequire('@material-ui/core', 'ListItemSecondaryAction')
+#if mui.global @:native('MaterialUI.ListItemSecondaryAction') #else @:jsRequire('@material-ui/core', 'ListItemSecondaryAction') #end
 extern class ListItemSecondaryAction extends ReactComponentOfProps<ListItemSecondaryActionProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<ListItemSecondaryActionClassKey>
 		return ListItemSecondaryActionStyles.styles;

--- a/src/mui/core/ListItemText.hx
+++ b/src/mui/core/ListItemText.hx
@@ -17,7 +17,7 @@ typedef ListItemTextProps = {
 	@:optional var secondaryTypographyProps:Partial<TypographyProps>;
 }
 
-@:jsRequire('@material-ui/core', 'ListItemText')
+#if mui.global @:native('MaterialUI.ListItemText') #else @:jsRequire('@material-ui/core', 'ListItemText') #end
 extern class ListItemText extends ReactComponentOfProps<ListItemTextProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<ListItemTextClassKey>
 		return ListItemTextStyles.styles;

--- a/src/mui/core/ListSubheader.hx
+++ b/src/mui/core/ListSubheader.hx
@@ -16,7 +16,7 @@ typedef ListSubheaderProps = {
 	@:optional var inset:Bool;
 }
 
-@:jsRequire('@material-ui/core', 'ListSubheader')
+#if mui.global @:native('MaterialUI.ListSubheader') #else @:jsRequire('@material-ui/core', 'ListSubheader') #end
 extern class ListSubheader extends ReactComponentOfProps<ListSubheaderProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<ListSubheaderClassKey>
 		return ListSubheaderStyles.styles(theme);

--- a/src/mui/core/Menu.hx
+++ b/src/mui/core/Menu.hx
@@ -16,7 +16,7 @@ typedef MenuProps = ForcedOverride<PopoverProps, {
 	@:optional var variant:MenuVariant;
 }>;
 
-@:jsRequire('@material-ui/core', 'Menu')
+#if mui.global @:native('MaterialUI.Menu') #else @:jsRequire('@material-ui/core', 'Menu') #end
 extern class Menu extends ReactComponentOfProps<MenuProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<MenuClassKey>
 		return MenuStyles.styles;

--- a/src/mui/core/MenuItem.hx
+++ b/src/mui/core/MenuItem.hx
@@ -10,7 +10,7 @@ typedef MenuItemProps = ForcedOverride<ListItemProps, {
 	@:optional var value:Any;
 }>;
 
-@:jsRequire('@material-ui/core', 'MenuItem')
+#if mui.global @:native('MaterialUI.MenuItem') #else @:jsRequire('@material-ui/core', 'MenuItem') #end
 extern class MenuItem extends ReactComponentOfProps<MenuItemProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<MenuItemClassKey>
 		return MenuItemStyles.styles(theme);

--- a/src/mui/core/MenuList.hx
+++ b/src/mui/core/MenuList.hx
@@ -12,5 +12,5 @@ typedef MenuListProps = {
 	@:optional var variant:MenuVariant;
 }
 
-@:jsRequire('@material-ui/core', 'MenuList')
+#if mui.global @:native('MaterialUI.MenuList') #else @:jsRequire('@material-ui/core', 'MenuList') #end
 extern class MenuList extends ReactComponentOfProps<MenuListProps> {}

--- a/src/mui/core/MobileStepper.hx
+++ b/src/mui/core/MobileStepper.hx
@@ -18,7 +18,7 @@ typedef MobileStepperProps = ForcedOverride<PaperProps, {
 	@:optional var variant:MobileStepperVariant;
 }>;
 
-@:jsRequire('@material-ui/core', 'MobileStepper')
+#if mui.global @:native('MaterialUI.MobileStepper') #else @:jsRequire('@material-ui/core', 'MobileStepper') #end
 extern class MobileStepper extends ReactComponentOfProps<MobileStepperProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<MobileStepperClassKey>
 		return MobileStepperStyles.styles(theme);

--- a/src/mui/core/Modal.hx
+++ b/src/mui/core/Modal.hx
@@ -29,5 +29,5 @@ typedef ModalProps = {
 	@:optional var onRendered:HandlerOrVoid<ClassicHandler>;
 }
 
-@:jsRequire('@material-ui/core', 'Modal')
+#if mui.global @:native('MaterialUI.Modal') #else @:jsRequire('@material-ui/core', 'Modal') #end
 extern class Modal extends ReactComponentOfProps<ModalProps> {}

--- a/src/mui/core/NativeSelect.hx
+++ b/src/mui/core/NativeSelect.hx
@@ -14,7 +14,7 @@ typedef NativeSelectProps = ForcedOverride<InputProps, {
 	@:optional var variant:FormControlVariant;
 }>;
 
-@:jsRequire('@material-ui/core', 'NativeSelect')
+#if mui.global @:native('MaterialUI.NativeSelect') #else @:jsRequire('@material-ui/core', 'NativeSelect') #end
 extern class NativeSelect extends ReactComponentOfProps<NativeSelectProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<NativeSelectClassKey>
 		return NativeSelectStyles.styles(theme);

--- a/src/mui/core/NoSsr.hx
+++ b/src/mui/core/NoSsr.hx
@@ -8,5 +8,5 @@ private typedef Props = {
 	@:optional var fallback:ReactFragment;
 }
 
-@:jsRequire('@material-ui/core', 'NoSsr')
+#if mui.global @:native('MaterialUI.NoSsr') #else @:jsRequire('@material-ui/core', 'NoSsr') #end
 extern class NoSsr extends ReactComponentOfProps<Props> {}

--- a/src/mui/core/OutlinedInput.hx
+++ b/src/mui/core/OutlinedInput.hx
@@ -11,7 +11,7 @@ typedef OutlinedInputProps = ForcedOverride<InputBaseProps, {
 	@:optional var notched:Bool;
 }>;
 
-@:jsRequire('@material-ui/core', 'OutlinedInput')
+#if mui.global @:native('MaterialUI.OutlinedInput') #else @:jsRequire('@material-ui/core', 'OutlinedInput') #end
 extern class OutlinedInput extends ReactComponentOfProps<OutlinedInputProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<OutlinedInputClassKey>
 		return OutlinedInputStyles.styles(theme);

--- a/src/mui/core/Paper.hx
+++ b/src/mui/core/Paper.hx
@@ -16,7 +16,7 @@ typedef PaperProps = {
 	
 }
 
-@:jsRequire('@material-ui/core', 'Paper')
+#if mui.global @:native('MaterialUI.Paper') #else @:jsRequire('@material-ui/core', 'Paper') #end
 extern class Paper extends ReactComponentOfProps<PaperProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<PaperClassKey>
 		return PaperStyles.styles(theme);

--- a/src/mui/core/Popover.hx
+++ b/src/mui/core/Popover.hx
@@ -36,7 +36,7 @@ typedef PopoverProps = ForcedOverride<ModalProps, {
 	@:optional var TransitionProps:TransitionProps<Any>;
 }>;
 
-@:jsRequire('@material-ui/core', 'Popover')
+#if mui.global @:native('MaterialUI.Popover') #else @:jsRequire('@material-ui/core', 'Popover') #end
 extern class Popover extends ReactComponentOfProps<PopoverProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<PopoverClassKey>
 		return PopoverStyles.styles;

--- a/src/mui/core/Popper.hx
+++ b/src/mui/core/Popper.hx
@@ -33,5 +33,5 @@ typedef PopperProps = {
 	@:optional var transition:Bool;
 }
 
-@:jsRequire('@material-ui/core', 'Popper')
+#if mui.global @:native('MaterialUI.Popper') #else @:jsRequire('@material-ui/core', 'Popper') #end
 extern class Popper extends ReactComponentOfProps<PopperProps> {}

--- a/src/mui/core/Portal.hx
+++ b/src/mui/core/Portal.hx
@@ -9,5 +9,5 @@ private typedef Props = {
 	@:optional var onRendered:Void->Void;
 }
 
-@:jsRequire('@material-ui/core', 'Portal')
+#if mui.global @:native('MaterialUI.Portal') #else @:jsRequire('@material-ui/core', 'Portal') #end
 extern class Portal extends ReactComponentOfProps<Props> {}

--- a/src/mui/core/Radio.hx
+++ b/src/mui/core/Radio.hx
@@ -28,7 +28,7 @@ typedef RadioProps = ForcedOverride<IconButtonProps, {
 	@:optional var value:RadioValue;
 }>;
 
-@:jsRequire('@material-ui/core', 'Radio')
+#if mui.global @:native('MaterialUI.Radio') #else @:jsRequire('@material-ui/core', 'Radio') #end
 extern class Radio extends ReactComponentOfProps<RadioProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<RadioClassKey>
 		return RadioStyles.styles(theme);

--- a/src/mui/core/RadioGroup.hx
+++ b/src/mui/core/RadioGroup.hx
@@ -10,5 +10,5 @@ typedef RadioGroupProps = ForcedOverride<FormGroupProps, {
 	@:optional var defaultValue:RadioValue;
 }>;
 
-@:jsRequire('@material-ui/core', 'RadioGroup')
+#if mui.global @:native('MaterialUI.RadioGroup') #else @:jsRequire('@material-ui/core', 'RadioGroup') #end
 extern class RadioGroup extends ReactComponentOfProps<RadioGroupProps> {}

--- a/src/mui/core/RootRef.hx
+++ b/src/mui/core/RootRef.hx
@@ -8,5 +8,5 @@ private typedef Props<T> = {
 	var rootRef:ReactRef<T>;
 }
 
-@:jsRequire('@material-ui/core', 'RootRef')
+#if mui.global @:native('MaterialUI.RootRef') #else @:jsRequire('@material-ui/core', 'RootRef') #end
 extern class RootRef<T> extends ReactComponentOfProps<Props<T>> {}

--- a/src/mui/core/Select.hx
+++ b/src/mui/core/Select.hx
@@ -31,7 +31,7 @@ typedef SelectProps<TData> = ForcedOverride<InputProps, {
 	@:optional var variant:FormControlVariant;
 }>;
 
-@:jsRequire('@material-ui/core', 'Select')
+#if mui.global @:native('MaterialUI.Select') #else @:jsRequire('@material-ui/core', 'Select') #end
 extern class Select<TData> extends ReactComponentOfProps<SelectProps<TData>> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<SelectClassKey>
 		return SelectStyles.styles(theme);

--- a/src/mui/core/Slide.hx
+++ b/src/mui/core/Slide.hx
@@ -11,5 +11,5 @@ typedef SlideProps = {
 }
 
 @:acceptsMoreProps('react.transition.Transition')
-@:jsRequire('@material-ui/core', 'Slide')
+#if mui.global @:native('MaterialUI.Slide') #else @:jsRequire('@material-ui/core', 'Slide') #end
 extern class Slide extends ReactComponentOfProps<SlideProps> {}

--- a/src/mui/core/Slider.hx
+++ b/src/mui/core/Slider.hx
@@ -37,7 +37,7 @@ typedef SliderProps = ForcedOverride<StandardDOMAttributes, {
 	@:optional var valueLabelFormat:EitherType<String, {value:Float, index:Int}->ReactFragment>;
 }>;
 
-@:jsRequire('@material-ui/core', 'Slider')
+#if mui.global @:native('MaterialUI.Slider') #else @:jsRequire('@material-ui/core', 'Slider') #end
 extern class Slider extends ReactComponentOfProps<SliderProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<SliderClassKey>
 		return SliderStyles.styles(theme);

--- a/src/mui/core/Snackbar.hx
+++ b/src/mui/core/Snackbar.hx
@@ -36,7 +36,7 @@ typedef SnackbarProps = {
 	@:optional var TransitionProps:TransitionProps<Any>;
 }
 
-@:jsRequire('@material-ui/core', 'Snackbar')
+#if mui.global @:native('MaterialUI.Snackbar') #else @:jsRequire('@material-ui/core', 'Snackbar') #end
 extern class Snackbar extends ReactComponentOfProps<SnackbarProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<SnackbarClassKey>
 		return SnackbarStyles.styles(theme);

--- a/src/mui/core/SnackbarContent.hx
+++ b/src/mui/core/SnackbarContent.hx
@@ -12,7 +12,7 @@ typedef SnackbarContentProps = ForcedOverride<PaperProps, {
 	@:optional var role:SnackbarContentRole;
 }>;
 
-@:jsRequire('@material-ui/core', 'SnackbarContent')
+#if mui.global @:native('MaterialUI.SnackbarContent') #else @:jsRequire('@material-ui/core', 'SnackbarContent') #end
 extern class SnackbarContent extends ReactComponentOfProps<SnackbarContentProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<SnackbarContentClassKey>
 		return SnackbarContentStyles.styles(theme);

--- a/src/mui/core/Step.hx
+++ b/src/mui/core/Step.hx
@@ -13,7 +13,7 @@ typedef StepProps = {
 	@:optional var disabled:Bool;
 }
 
-@:jsRequire('@material-ui/core', 'Step')
+#if mui.global @:native('MaterialUI.Step') #else @:jsRequire('@material-ui/core', 'Step') #end
 extern class Step extends ReactComponentOfProps<StepProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<StepClassKey>
 		return StepStyles.styles;

--- a/src/mui/core/StepButton.hx
+++ b/src/mui/core/StepButton.hx
@@ -12,7 +12,7 @@ typedef StepButtonProps = {
 	@:optional var optional:ReactFragment;
 }
 
-@:jsRequire('@material-ui/core', 'StepButton')
+#if mui.global @:native('MaterialUI.StepButton') #else @:jsRequire('@material-ui/core', 'StepButton') #end
 extern class StepButton extends ReactComponentOfProps<StepButtonProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<StepButtonClassKey>
 		return StepButtonStyles.styles;

--- a/src/mui/core/StepConnector.hx
+++ b/src/mui/core/StepConnector.hx
@@ -10,7 +10,7 @@ typedef StepConnectorProps = {
 	@:optional var classes:Record<StepConnectorClassKey>;
 }
 
-@:jsRequire('@material-ui/core', 'StepConnector')
+#if mui.global @:native('MaterialUI.StepConnector') #else @:jsRequire('@material-ui/core', 'StepConnector') #end
 extern class StepConnector extends ReactComponentOfProps<StepConnectorProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<StepConnectorClassKey>
 		return StepConnectorStyles.styles(theme);

--- a/src/mui/core/StepContent.hx
+++ b/src/mui/core/StepContent.hx
@@ -16,7 +16,7 @@ typedef StepContentProps = {
 	@:optional var TransitionProps:TransitionProps<Any>;
 }
 
-@:jsRequire('@material-ui/core', 'StepContent')
+#if mui.global @:native('MaterialUI.StepContent') #else @:jsRequire('@material-ui/core', 'StepContent') #end
 extern class StepContent extends ReactComponentOfProps<StepContentProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<StepContentClassKey>
 		return StepContentStyles.styles(theme);

--- a/src/mui/core/StepIcon.hx
+++ b/src/mui/core/StepIcon.hx
@@ -14,7 +14,7 @@ typedef StepIconProps = {
 	@:optional var error:Bool;
 }
 
-@:jsRequire('@material-ui/core', 'StepIcon')
+#if mui.global @:native('MaterialUI.StepIcon') #else @:jsRequire('@material-ui/core', 'StepIcon') #end
 extern class StepIcon extends ReactComponentOfProps<StepIconProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<StepIconClassKey>
 		return StepIconStyles.styles(theme);

--- a/src/mui/core/StepLabel.hx
+++ b/src/mui/core/StepLabel.hx
@@ -17,7 +17,7 @@ typedef StepLabelProps = {
 	@:optional var StepIconProps:Partial<StepIconProps>;
 }
 
-@:jsRequire('@material-ui/core', 'StepLabel')
+#if mui.global @:native('MaterialUI.StepLabel') #else @:jsRequire('@material-ui/core', 'StepLabel') #end
 extern class StepLabel extends ReactComponentOfProps<StepLabelProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<StepLabelClassKey>
 		return StepLabelStyles.styles(theme);

--- a/src/mui/core/Stepper.hx
+++ b/src/mui/core/Stepper.hx
@@ -15,7 +15,7 @@ typedef StepperProps = ForcedOverride<PaperProps, {
 	@:optional var orientation:Orientation;
 }>;
 
-@:jsRequire('@material-ui/core', 'Stepper')
+#if mui.global @:native('MaterialUI.Stepper') #else @:jsRequire('@material-ui/core', 'Stepper') #end
 extern class Stepper extends ReactComponentOfProps<StepperProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<StepperClassKey>
 		return StepperStyles.styles;

--- a/src/mui/core/SvgIcon.hx
+++ b/src/mui/core/SvgIcon.hx
@@ -18,7 +18,7 @@ typedef SvgIconProps = {
 	@:optional var viewBox:String;
 }
 
-@:jsRequire('@material-ui/core', 'SvgIcon')
+#if mui.global @:native('MaterialUI.SvgIcon') #else @:jsRequire('@material-ui/core', 'SvgIcon') #end
 extern class SvgIcon extends ReactComponentOfProps<SvgIconProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<SvgIconClassKey>
 		return SvgIconStyles.styles(theme);

--- a/src/mui/core/SwipeableDrawer.hx
+++ b/src/mui/core/SwipeableDrawer.hx
@@ -19,5 +19,5 @@ typedef SwipeableDrawerProps = {
 	@:optional var transitionDuration:TransitionDuration;
 }
 
-@:jsRequire('@material-ui/core', 'SwipeableDrawer')
+#if mui.global @:native('MaterialUI.SwipeableDrawer') #else @:jsRequire('@material-ui/core', 'SwipeableDrawer') #end
 extern class SwipeableDrawer extends ReactComponentOfProps<SwipeableDrawerProps> {}

--- a/src/mui/core/Switch.hx
+++ b/src/mui/core/Switch.hx
@@ -30,7 +30,7 @@ typedef SwitchProps = ForcedOverride<StandardDOMAttributes, {
 	@:optional var value:String;
 }>;
 
-@:jsRequire('@material-ui/core', 'Switch')
+#if mui.global @:native('MaterialUI.Switch') #else @:jsRequire('@material-ui/core', 'Switch') #end
 extern class Switch extends ReactComponentOfProps<SwitchProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<SwitchClassKey>
 		return SwitchStyles.styles(theme);

--- a/src/mui/core/Tab.hx
+++ b/src/mui/core/Tab.hx
@@ -14,7 +14,7 @@ typedef TabProps = ForcedOverride<ButtonBaseProps, {
 	@:optional var wrapped:Bool;
 }>;
 
-@:jsRequire('@material-ui/core', 'Tab')
+#if mui.global @:native('MaterialUI.Tab') #else @:jsRequire('@material-ui/core', 'Tab') #end
 extern class Tab extends ReactComponentOfProps<TabProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<TabClassKey>
 		return TabStyles.styles(theme);

--- a/src/mui/core/Table.hx
+++ b/src/mui/core/Table.hx
@@ -16,7 +16,7 @@ typedef TableProps = {
 	@:optional var stickyHeader:Bool;
 }
 
-@:jsRequire('@material-ui/core', 'Table')
+#if mui.global @:native('MaterialUI.Table') #else @:jsRequire('@material-ui/core', 'Table') #end
 extern class Table extends ReactComponentOfProps<TableProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<TableClassKey>
 		return TableStyles.styles(theme);

--- a/src/mui/core/TableBody.hx
+++ b/src/mui/core/TableBody.hx
@@ -11,7 +11,7 @@ typedef TableBodyProps = {
 	@:optional var component:ReactType;
 }
 
-@:jsRequire('@material-ui/core', 'TableBody')
+#if mui.global @:native('MaterialUI.TableBody') #else @:jsRequire('@material-ui/core', 'TableBody') #end
 extern class TableBody extends ReactComponentOfProps<TableBodyProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<TableBodyClassKey>
 		return TableBodyStyles.styles;

--- a/src/mui/core/TableCell.hx
+++ b/src/mui/core/TableCell.hx
@@ -25,7 +25,7 @@ typedef TableCellProps = {
 	@:optional var rowSpan:Int;
 }
 
-@:jsRequire('@material-ui/core', 'TableCell')
+#if mui.global @:native('MaterialUI.TableCell') #else @:jsRequire('@material-ui/core', 'TableCell') #end
 extern class TableCell extends ReactComponentOfProps<TableCellProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<TableCellClassKey>
 		return TableCellStyles.styles(theme);

--- a/src/mui/core/TableFooter.hx
+++ b/src/mui/core/TableFooter.hx
@@ -11,7 +11,7 @@ typedef TableFooterProps = {
 	@:optional var component:ReactType;
 }
 
-@:jsRequire('@material-ui/core', 'TableFooter')
+#if mui.global @:native('MaterialUI.TableFooter') #else @:jsRequire('@material-ui/core', 'TableFooter') #end
 extern class TableFooter extends ReactComponentOfProps<TableFooterProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<TableFooterClassKey>
 		return TableFooterStyles.styles;

--- a/src/mui/core/TableHead.hx
+++ b/src/mui/core/TableHead.hx
@@ -11,7 +11,7 @@ typedef TableHeadProps = {
 	@:optional var component:ReactType;
 }
 
-@:jsRequire('@material-ui/core', 'TableHead')
+#if mui.global @:native('MaterialUI.TableHead') #else @:jsRequire('@material-ui/core', 'TableHead') #end
 extern class TableHead extends ReactComponentOfProps<TableHeadProps> {
 	static inline function styles<TTheme>(?_:TTheme):ClassesDef<TableHeadClassKey>
 		return TableHeadStyles.styles;

--- a/src/mui/core/TablePagination.hx
+++ b/src/mui/core/TablePagination.hx
@@ -30,7 +30,7 @@ typedef TablePaginationProps = ForcedOverride<TableCellProps, {
 	@:optional var SelectProps:Partial<SelectProps<Int>>;
 }>;
 
-@:jsRequire('@material-ui/core', 'TablePagination')
+#if mui.global @:native('MaterialUI.TablePagination') #else @:jsRequire('@material-ui/core', 'TablePagination') #end
 extern class TablePagination extends ReactComponentOfProps<TablePaginationProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<TablePaginationClassKey>
 		return TablePaginationStyles.styles(theme);

--- a/src/mui/core/TableRow.hx
+++ b/src/mui/core/TableRow.hx
@@ -13,7 +13,7 @@ typedef TableRowProps = {
 	@:optional var component:ReactType;
 }
 
-@:jsRequire('@material-ui/core', 'TableRow')
+#if mui.global @:native('MaterialUI.TableRow') #else @:jsRequire('@material-ui/core', 'TableRow') #end
 extern class TableRow extends ReactComponentOfProps<TableRowProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<TableRowClassKey>
 		return TableRowStyles.styles(theme);

--- a/src/mui/core/TableSortLabel.hx
+++ b/src/mui/core/TableSortLabel.hx
@@ -15,7 +15,7 @@ typedef TableSortLabelProps = {
 	@:optional var IconComponent:ReactType;
 }
 
-@:jsRequire('@material-ui/core', 'TableSortLabel')
+#if mui.global @:native('MaterialUI.TableSortLabel') #else @:jsRequire('@material-ui/core', 'TableSortLabel') #end
 extern class TableSortLabel extends ReactComponentOfProps<TableSortLabelProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<TableSortLabelClassKey>
 		return TableSortLabelStyles.styles(theme);

--- a/src/mui/core/Tabs.hx
+++ b/src/mui/core/Tabs.hx
@@ -25,7 +25,7 @@ typedef TabsProps<Data> = ForcedOverride<StandardDOMAttributes, {
 	@:optional var variant:TabsVariant;
 }>;
 
-@:jsRequire('@material-ui/core', 'Tabs')
+#if mui.global @:native('MaterialUI.Tabs') #else @:jsRequire('@material-ui/core', 'Tabs') #end
 extern class Tabs<Data> extends ReactComponentOfProps<TabsProps<Data>> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<TabsClassKey>
 		return TabsStyles.styles(theme);

--- a/src/mui/core/TextField.hx
+++ b/src/mui/core/TextField.hx
@@ -23,5 +23,5 @@ typedef TextFieldProps<TData> = ForcedOverride<FormControlProps, {
 	@:optional var size:FormControlSize;
 }>;
 
-@:jsRequire('@material-ui/core', 'TextField')
+#if mui.global @:native('MaterialUI.TextField') #else @:jsRequire('@material-ui/core', 'TextField') #end
 extern class TextField<TData> extends ReactComponentOfProps<TextFieldProps<TData>> {}

--- a/src/mui/core/TextareaAutosize.hx
+++ b/src/mui/core/TextareaAutosize.hx
@@ -12,5 +12,5 @@ typedef TextareaAutosizeProps = ForcedOverride<StandardDOMAttributes, {
 	@:optional var value:InputValue;
 }>;
 
-@:jsRequire('@material-ui/core', 'TextareaAutosize')
+#if mui.global @:native('MaterialUI.TextareaAutosize') #else @:jsRequire('@material-ui/core', 'TextareaAutosize') #end
 extern class TextareaAutosize extends ReactComponentOfProps<TextareaAutosizeProps> {}

--- a/src/mui/core/Toolbar.hx
+++ b/src/mui/core/Toolbar.hx
@@ -13,7 +13,7 @@ typedef ToolbarProps = {
 	@:optional var variant:ToolbarVariant;
 }
 
-@:jsRequire('@material-ui/core', 'Toolbar')
+#if mui.global @:native('MaterialUI.Toolbar') #else @:jsRequire('@material-ui/core', 'Toolbar') #end
 extern class Toolbar extends ReactComponentOfProps<ToolbarProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<ToolbarClassKey>
 		return ToolbarStyles.styles(theme);

--- a/src/mui/core/Tooltip.hx
+++ b/src/mui/core/Tooltip.hx
@@ -29,7 +29,7 @@ typedef TooltipProps = ForcedOverride<StandardDOMAttributes, {
 	@:optional var TransitionProps:TransitionProps<Any>;
 }>;
 
-@:jsRequire('@material-ui/core', 'Tooltip')
+#if mui.global @:native('MaterialUI.Tooltip') #else @:jsRequire('@material-ui/core', 'Tooltip') #end
 extern class Tooltip extends ReactComponentOfProps<TooltipProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<TooltipClassKey>
 		return TooltipStyles.styles(theme);

--- a/src/mui/core/Typography.hx
+++ b/src/mui/core/Typography.hx
@@ -25,7 +25,7 @@ typedef TypographyProps = {
 	@:optional var variantMapping:TypographyVariantMapping;
 }
 
-@:jsRequire('@material-ui/core', 'Typography')
+#if mui.global @:native('MaterialUI.Typography') #else @:jsRequire('@material-ui/core', 'Typography') #end
 extern class Typography extends ReactComponentOfProps<TypographyProps> {
 	static inline function styles<TTheme>(theme:TTheme):ClassesDef<TypographyClassKey>
 		return TypographyStyles.styles(theme);

--- a/src/mui/core/Zoom.hx
+++ b/src/mui/core/Zoom.hx
@@ -4,5 +4,5 @@ import react.ReactComponent;
 import react.transition.Transition;
 
 @:acceptsMoreProps('react.transition.Transition')
-@:jsRequire('@material-ui/core', 'Zoom')
+#if mui.global @:native('MaterialUI.Zoom') #else @:jsRequire('@material-ui/core', 'Zoom') #end
 extern class Zoom<TChildProps> extends ReactComponentOfProps<TransitionProps<TChildProps>> {}

--- a/src/mui/core/modal/ModalManager.hx
+++ b/src/mui/core/modal/ModalManager.hx
@@ -5,7 +5,7 @@ typedef ModalManagerOptions = {
 	@:optional var handleContainerOverflow:Bool;
 }
 
-@:jsRequire('@material-ui/core', 'ModalManager')
+#if mui.global @:native('MaterialUI.ModalManager') #else @:jsRequire('@material-ui/core', 'ModalManager') #end
 extern class ModalManager {
 	public function new(options:ModalManagerOptions);
 	public function add(modal:Any, container:Any):Int;

--- a/src/mui/icon/Icon.hx
+++ b/src/mui/icon/Icon.hx
@@ -2,6 +2,6 @@ package mui.icon;
 
 import react.ReactComponent;
 
-@:jsRequire('@material-ui/core', 'Icon')
+#if mui.global @:native('MaterialUI.Icon') #else @:jsRequire('@material-ui/core', 'Icon') #end
 extern class Icon extends ReactComponentOfProps<IconProps> {}
 


### PR DESCRIPTION
Support adding `-D mui.global` to switch to `@:native` generation so we can use UMD module without the build process